### PR TITLE
Fix Spotify token refresh

### DIFF
--- a/src/store/modules/spotify.js
+++ b/src/store/modules/spotify.js
@@ -44,8 +44,8 @@ const actions = {
       commit('SET_ACCESS_TOKEN', data.access_token) 
       return data.access_token
     } catch (e) {
-      dispatch('login')
       console.log(e) // eslint-disable-line 
+      await dispatch('login')
     }
   },
 
@@ -184,7 +184,7 @@ async function get (route, cache = false, { accessToken, dispatch, dropRoot = fa
       }
     }
   } catch (e) {
-    window.location.replace(`${PROJECT_ROOT}/api/authentication/login`) // eslint-disable-line
+    await dispatch('login')
   }
 }
 

--- a/src/store/modules/spotify.js
+++ b/src/store/modules/spotify.js
@@ -209,7 +209,7 @@ async function post (route, args = {}, { accessToken, dispatch }, root = ROOT) {
   } catch ({ response }) {
     if (response.status === 401) {
       const token = await dispatch('refresh')
-      return put(route, args, { accessToken: token, dispatch })
+      return post(route, args, { accessToken: token, dispatch }, root)
     }
   }
 }

--- a/src/store/modules/spotify.js
+++ b/src/store/modules/spotify.js
@@ -2,7 +2,7 @@ import { buildModule } from '@zach.winter/vue-common/util/store'
 import * as cookies from '@zach.winter/common/js/cookies'
 import axios from 'axios'
 
-const ROOT = 'https://api.spotify.com/v1'
+const SPOTIFY_ROOT = 'https://api.spotify.com/v1'
 const CACHE = new Set()
 
 const state = {
@@ -64,12 +64,12 @@ const actions = {
   },
 
   getPlaylistTracks ({ state, dispatch }, track) {
-    return get(track, false, { accessToken: state.accessToken, dispatch, dropRoot: true })
+    return get(track, false, { accessToken: state.accessToken, dispatch })
   },
 
   async getUser ({ state, dispatch }) {
     try {
-      const user = await get('me', false, { accessToken: state.accessToken, dispatch })
+      const user = await get(`${SPOTIFY_ROOT}/me`, false, { accessToken: state.accessToken, dispatch })
       dispatch('saveUser', user)
       return user 
     } catch (e) {
@@ -86,101 +86,101 @@ const actions = {
   },
 
   getUserDevices ({ state, dispatch }) {
-    return get('me/player/devices', null, { accessToken: state.accessToken, dispatch  })
+    return get(`${SPOTIFY_ROOT}/me/player/devices`, null, { accessToken: state.accessToken, dispatch  })
   },
   
   getCurrentlyPlaying ({ state, dispatch  }) {
-    return get('me/player', null, { accessToken: state.accessToken, dispatch })
+    return get(`${SPOTIFY_ROOT}/me/player`, null, { accessToken: state.accessToken, dispatch })
   },
   
   selectDevice ({ state, dispatch  }, device) {
-    return put('me/player', { device_ids: [device], play: true }, { accessToken: state.accessToken, dispatch })
+    return put(`${SPOTIFY_ROOT}/me/player`, { device_ids: [device], play: true }, { accessToken: state.accessToken, dispatch })
   },
   
   getUserPlaylists ({ state, dispatch }) {
-    return get('me/playlists', null, { accessToken: state.accessToken, dispatch })
+    return get(`${SPOTIFY_ROOT}/me/playlists`, null, { accessToken: state.accessToken, dispatch })
   },
   
   getRecentlyPlayedTracks ({ state, dispatch }) {
-    return get('me/player/recently-played?limit=50', null, { accessToken: state.accessToken, dispatch })
+    return get(`${SPOTIFY_ROOT}/me/player/recently-played?limit=50`, null, { accessToken: state.accessToken, dispatch })
   },
   
   getTopArtists ({ state, dispatch }) {
-    return get('me/top/artists', true, { accessToken: state.accessToken, dispatch })
+    return get(`${SPOTIFY_ROOT}/me/top/artists`, true, { accessToken: state.accessToken, dispatch })
   },
   
   getTopTracks ({ state, dispatch }) {
-    return get('me/top/tracks', true, { accessToken: state.accessToken, dispatch })
+    return get(`${SPOTIFY_ROOT}/me/top/tracks`, true, { accessToken: state.accessToken, dispatch })
   },
   
   search ({ state, dispatch }, query) {
-    return get(`search?q=${query}&type=artist,album,track&limit=5`, true, { accessToken: state.accessToken, dispatch })
+    return get(`${SPOTIFY_ROOT}/search?q=${query}&type=artist,album,track&limit=5`, true, { accessToken: state.accessToken, dispatch })
   },
   
   getArtist ({ state, dispatch }, id) {
-    return get(`artists/${id}`, true, { accessToken: state.accessToken, dispatch })
+    return get(`${SPOTIFY_ROOT}/artists/${id}`, true, { accessToken: state.accessToken, dispatch })
   },
   
   getAlbum ({ state, dispatch }, id) {
-    return get(`albums/${id}`, true, { accessToken: state.accessToken, dispatch })
+    return get(`${SPOTIFY_ROOT}/albums/${id}`, true, { accessToken: state.accessToken, dispatch })
   },
   getArtistAlbums ({ state, dispatch }, id) {
-    return get(`artists/${id}/albums`, true, { accessToken: state.accessToken, dispatch })
+    return get(`${SPOTIFY_ROOT}/artists/${id}/albums`, true, { accessToken: state.accessToken, dispatch })
   },
   
   getRelatedArtists ({ state, dispatch }, id) {
-    return get(`artists/${id}/related-artists`, true, { accessToken: state.accessToken, dispatch })
+    return get(`${SPOTIFY_ROOT}/artists/${id}/related-artists`, true, { accessToken: state.accessToken, dispatch })
   },
   
   getAlbumTracks ({ state, dispatch }, id) {
-    return get(`albums/${id}/tracks`, true, { accessToken: state.accessToken, dispatch })
+    return get(`${SPOTIFY_ROOT}/albums/${id}/tracks`, true, { accessToken: state.accessToken, dispatch })
   },
   
   getFeaturedPlaylists ({ state, dispatch }) {
-    return get('browse/featured-playlists', true, { accessToken: state.accessToken, dispatch })
+    return get(`${SPOTIFY_ROOT}/browse/featured-playlists`, true, { accessToken: state.accessToken, dispatch })
   },
   
   postTrackToQueue ({ state, dispatch }, track) {
-    return post(`me/player/queue?uri=${track}`, false, { accessToken: state.accessToken, dispatch })
+    return post(`${SPOTIFY_ROOT}/me/player/queue?uri=${track}`, false, { accessToken: state.accessToken, dispatch })
   },
   
   getTrackAnalysis ({ state, dispatch }, id) {
-    return get(`audio-analysis/${id}`, false, { accessToken: state.accessToken, dispatch })
+    return get(`${SPOTIFY_ROOT}/audio-analysis/${id}`, false, { accessToken: state.accessToken, dispatch })
   },
   
   play ({ state, dispatch }, songs = null) {
-    return put('me/player/play', songs, { accessToken: state.accessToken, dispatch })
+    return put(`${SPOTIFY_ROOT}/me/player/play`, songs, { accessToken: state.accessToken, dispatch })
   },
   
   pause ({ state, dispatch }) {
-    return put('me/player/pause', null, { accessToken: state.accessToken, dispatch })
+    return put(`${SPOTIFY_ROOT}/me/player/pause`, null, { accessToken: state.accessToken, dispatch })
   },
   
   next ({ state, dispatch }) {
-    return post('me/player/next', null, { accessToken: state.accessToken, dispatch })
+    return post(`${SPOTIFY_ROOT}/me/player/next`, null, { accessToken: state.accessToken, dispatch })
   },
   
   previous ({ state, dispatch }) {
-    return post('me/player/previous', null, { accessToken: state.accessToken, dispatch })
+    return post(`${SPOTIFY_ROOT}/me/player/previous`, null, { accessToken: state.accessToken, dispatch })
   },
   
   getPlaylist ({ state, dispatch }, id) {
-    return get(`playlists/${id}`, false, { accessToken: state.accessToken, dispatch })
+    return get(`${SPOTIFY_ROOT}/playlists/${id}`, false, { accessToken: state.accessToken, dispatch })
   }
 }
 
-async function get (route, cache = false, { accessToken, dispatch, dropRoot = false } = {}) {
+async function get (route, cache = false, { accessToken, dispatch } = {}) {
   try {
     if (cache && CACHE[route]) return CACHE[route]
     const headers = { Authorization: `Bearer ${accessToken}`, Accept: 'application/json' }
     try {
-      const { data } = await axios.get(dropRoot ? route : `${ROOT}/${route}`, { headers })
+      const { data } = await axios.get(route, { headers })
       if (cache) CACHE[route] = data
       return data
     } catch ({ response }) {
       if (response.status === 401) {
         const token = await dispatch('refresh')
-        return get(route, cache, { accessToken: token, dispatch, dropRoot })
+        return get(route, cache, { accessToken: token, dispatch })
       }
     }
   } catch (e) {
@@ -191,7 +191,7 @@ async function get (route, cache = false, { accessToken, dispatch, dropRoot = fa
 async function put (route, args, { accessToken, dispatch }) {
   const headers = { Authorization: `Bearer ${accessToken}`, Accept: 'application/json' }
   try {
-    const { data } = await axios.put(`${ROOT}/${route}`, args, { headers })
+    const { data } = await axios.put(route, args, { headers })
     return data
   } catch ({ response }) {
     if (response.status === 401) {
@@ -201,15 +201,15 @@ async function put (route, args, { accessToken, dispatch }) {
   }
 }
 
-async function post (route, args = {}, { accessToken, dispatch }, root = ROOT) {
+async function post (route, args = {}, { accessToken, dispatch }) {
   const headers = { Authorization: `Bearer ${accessToken}`, Accept: 'application/json' }
   try {
-    const { data } = await axios.post(`${root}/${route}`, args, { headers })
+    const { data } = await axios.post(route, args, { headers })
     return data
   } catch ({ response }) {
     if (response.status === 401) {
       const token = await dispatch('refresh')
-      return post(route, args, { accessToken: token, dispatch }, root)
+      return post(route, args, { accessToken: token, dispatch })
     }
   }
 }

--- a/src/store/modules/spotify.js
+++ b/src/store/modules/spotify.js
@@ -40,7 +40,7 @@ const actions = {
 
   async refresh ({ state, commit, dispatch }) {
     try {
-      const { data } = await get(`${PROJECT_ROOT}/api/authentication/refresh?token=${state.refreshToken}`, { accessToken: state.accessToken, dispatch }) //eslint-disable-line
+      const { data } = await get(`${PROJECT_ROOT}/api/authentication/refresh?token=${state.refreshToken}`, false, { accessToken: state.accessToken, dispatch, dropRoot: true }) //eslint-disable-line
       commit('SET_ACCESS_TOKEN', data.access_token) 
       return data.access_token
     } catch (e) {
@@ -180,7 +180,7 @@ async function get (route, cache = false, { accessToken, dispatch, dropRoot = fa
     } catch ({ response }) {
       if (response.status === 401) {
         const token = await dispatch('refresh')
-        return get(route, cache, { accessToken: token, dispatch })
+        return get(route, cache, { accessToken: token, dispatch, dropRoot })
       }
     }
   } catch (e) {

--- a/src/store/modules/spotify.js
+++ b/src/store/modules/spotify.js
@@ -40,7 +40,7 @@ const actions = {
 
   async refresh ({ state, commit, dispatch }) {
     try {
-      const { data } = await get(`${PROJECT_ROOT}/api/authentication/refresh?token=${state.refreshToken}`, false, { accessToken: state.accessToken, dispatch, dropRoot: true }) //eslint-disable-line
+      const { data } = await axios.get(`${PROJECT_ROOT}/api/authentication/refresh?token=${state.refreshToken}`) //eslint-disable-line
       commit('SET_ACCESS_TOKEN', data.access_token) 
       return data.access_token
     } catch (e) {

--- a/src/store/modules/spotify.js
+++ b/src/store/modules/spotify.js
@@ -47,6 +47,7 @@ const actions = {
   async refresh ({ state, commit, dispatch }) {
     try {
       const { data } = await axios.get(`${PROJECT_ROOT}/api/authentication/refresh?token=${state.refreshToken}`)
+      cookies.set(ACCESS_TOKEN, data.access_token); // update ACCESS_TOKEN cookie to have the new token if page reloads
       commit('SET_ACCESS_TOKEN', data.access_token) 
       return data.access_token
     } catch (e) {

--- a/src/store/modules/spotify.js
+++ b/src/store/modules/spotify.js
@@ -2,6 +2,12 @@ import { buildModule } from '@zach.winter/vue-common/util/store'
 import * as cookies from '@zach.winter/common/js/cookies'
 import axios from 'axios'
 
+/*global PROJECT_ROOT */
+/*global ACCESS_TOKEN */
+/*global REFRESH_TOKEN */
+/*global REFRESH_CODE */
+/*global DATA_URL */
+
 const SPOTIFY_ROOT = 'https://api.spotify.com/v1'
 const CACHE = new Set()
 
@@ -16,31 +22,31 @@ const state = {
 
 const actions = {
   validateCookies () {
-    const accessToken = cookies.get(ACCESS_TOKEN) // eslint-disable-line 
-    const refreshToken = cookies.get(REFRESH_TOKEN) // eslint-disable-line 
-    const refreshCode = cookies.get(REFRESH_CODE) // eslint-disable-line 
+    const accessToken = cookies.get(ACCESS_TOKEN)
+    const refreshToken = cookies.get(REFRESH_TOKEN)
+    const refreshCode = cookies.get(REFRESH_CODE)
     return [accessToken, refreshToken, refreshCode].every(v => v && v !== 'null')
   },
   async init ({ commit, dispatch }) {
     const valid = await dispatch('validateCookies')
     if (!valid) return await dispatch('login')
-    commit('SET_ACCESS_TOKEN', cookies.get(ACCESS_TOKEN)) // eslint-disable-line 
-    commit('SET_REFRESH_TOKEN', cookies.get(REFRESH_TOKEN)) // eslint-disable-line 
-    commit('SET_REFRESH_CODE', cookies.get(REFRESH_CODE)) // eslint-disable-line 
+    commit('SET_ACCESS_TOKEN', cookies.get(ACCESS_TOKEN))
+    commit('SET_REFRESH_TOKEN', cookies.get(REFRESH_TOKEN))
+    commit('SET_REFRESH_CODE', cookies.get(REFRESH_CODE))
     commit('SET_AUTHENTICATED', true)
     commit('SET_USER', await dispatch('getUser'))
   },
 
   async login () {
-    cookies.set(ACCESS_TOKEN, null) // eslint-disable-line
-    cookies.set(REFRESH_TOKEN, null) // eslint-disable-line
-    cookies.set(REFRESH_CODE, null) // eslint-disable-line 
-    window.location.replace(`${PROJECT_ROOT}/api/authentication/login`) // eslint-disable-line
+    cookies.set(ACCESS_TOKEN, null)
+    cookies.set(REFRESH_TOKEN, null)
+    cookies.set(REFRESH_CODE, null)
+    window.location.replace(`${PROJECT_ROOT}/api/authentication/login`)
   },
 
   async refresh ({ state, commit, dispatch }) {
     try {
-      const { data } = await axios.get(`${PROJECT_ROOT}/api/authentication/refresh?token=${state.refreshToken}`) //eslint-disable-line
+      const { data } = await axios.get(`${PROJECT_ROOT}/api/authentication/refresh?token=${state.refreshToken}`)
       commit('SET_ACCESS_TOKEN', data.access_token) 
       return data.access_token
     } catch (e) {
@@ -79,7 +85,7 @@ const actions = {
 
   async saveUser (a, user) {
     try {
-      await axios.post(DATA_URL, user) // eslint-disable-line
+      await axios.post(DATA_URL, user)
     } catch (e) {
       // :(
     }


### PR DESCRIPTION
The `/api/authentication/refresh` API call did not work because a wrong URL got constructed in the `get` helper function.

This pull request fixes the refresh mechanism and addresses some other more or less serious issues.

Code changes in this pull request are tested locally.

Hope this pull request helps and please reach out to me,
if I should change something to be consistent with your code style.