### PR TITLE
Fix visible scrollbars issue

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -16,6 +16,7 @@ export default {
 
 html, body {
   @include size(100%);
+  overflow: hidden;
 }
 
 body {

--- a/src/components/visualizer/SideBar.vue
+++ b/src/components/visualizer/SideBar.vue
@@ -68,6 +68,7 @@ export default {
   font-family: 'Share', sans-serif;
   text-transform: uppercase;
   padding: 1rem;
+  box-sizing: content-box;
 
   &.transparent {
     background: transparent;


### PR DESCRIPTION
In Edge v97 (Chromium-Based) the body element shows some scrollbars.

This pull request fixes the issue by setting `overflow: hidden` to the body element and as a consequence 
of this fix it was necessary to set `box-sizing: content-box` to `SideBar.vue`

Hope this pull request helps and please reach out to me,
if I should change something to be consistent with your code style.